### PR TITLE
[TASK] Fix travis using travis configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,14 @@ python:
   - "2.7"
   - "3.2"
   - "3.3"
+  - "3.4"
 
 install:
   - pip install -r requirements.txt
   - pip install -r requirements_test.txt
-  - pip install -r requirements_travis.txt
+
+  - if [[ $TRAVIS_PYTHON_VERSION == '3.2' ]]; then travis_retry pip install coveralls<=0.5; fi
+  - if [[ $TRAVIS_PYTHON_VERSION != '3.2' ]]; then travis_retry pip install -r requirements_travis.txt; fi
 
 script:
   - coverage run -m py.test

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ install:
   - pip install -r requirements.txt
   - pip install -r requirements_test.txt
 
-  - if [[ $TRAVIS_PYTHON_VERSION == '3.2' ]]; then travis_retry pip install coveralls<=0.5; fi
+  - if [[ $TRAVIS_PYTHON_VERSION == '3.2' ]]; then travis_retry pip install coveralls==0.5; fi
   - if [[ $TRAVIS_PYTHON_VERSION != '3.2' ]]; then travis_retry pip install -r requirements_travis.txt; fi
 
 script:


### PR DESCRIPTION
(Option 1)
Pin version of coveralls to 0.5 or less when using python 3.2 and
include python 3.4 which has become standard for many python3
installations.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/fuzeman/trakt.py/34)
<!-- Reviewable:end -->

fixes #36 