### PR TITLE
[BUGFIX] Special Season episodes

### DIFF
--- a/trakt/mapper/core/base.py
+++ b/trakt/mapper/core/base.py
@@ -59,8 +59,15 @@ class Mapper(object):
             keys.insert(0, item.get('number'))
 
         if media == 'episode':
+            # Special seasons are typically represented as Season '0'
+            # so using a simple 'or' condition to use parent will result
+            # in an attribute error if parent is None
+            season_no = item.get('season')
+            if season_no is None and parent is not None:
+                season_no = parent.pk
+
             keys.insert(0, (
-                item.get('season') or parent.pk,
+                season_no,
                 item.get('number')
             ))
 


### PR DESCRIPTION
Special episodes outside normal seasons are typically grouped under
season '0'. As such when using an 'or' condition against the value
of the season number or using parent primary key will result in
an attribute error. '0' is considered false in python and then
the parent for episodes is always None.

fixes #38

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/fuzeman/trakt.py/39)
<!-- Reviewable:end -->
