### PR TITLE
Added support for extended info for Trakt['shows'] interface

### DIFF
--- a/trakt/interfaces/shows/__init__.py
+++ b/trakt/interfaces/shows/__init__.py
@@ -5,40 +5,49 @@ from trakt.mapper.summary import SummaryMapper
 class ShowsInterface(Interface):
     path = 'shows'
 
-    def get(self, id, **kwargs):
+    def get(self, id, extended=None, **kwargs):
         response = self.http.get(
-            str(id)
-        )
+            str(id), query={
+                'extended': extended
+        })
 
         return SummaryMapper.show(
             self.client,
             self.get_data(response, **kwargs)
         )
 
-    def trending(self, **kwargs):
+    def trending(self, extended=None, **kwargs):
         response = self.http.get(
-            'trending'
-        )
+            'trending',
+            query={
+                'extended': extended
+        })
 
         return SummaryMapper.shows(
             self.client,
             self.get_data(response, **kwargs)
         )
 
-    def next_episode(self, id, **kwargs):
+    def next_episode(self, id, extended=None, **kwargs):
         response = self.http.get(
-            str(id), 'next_episode'
-        )
+            str(id), [
+                'next_episode'
+            ], query={
+                'extended': extended
+        })
 
         return SummaryMapper.episode(
             self.client,
             self.get_data(response, **kwargs)
         )
 
-    def last_episode(self, id, **kwargs):
+    def last_episode(self, id, extended=None, **kwargs):
         response = self.http.get(
-            str(id), 'last_episode'
-        )
+            str(id), [
+                'last_episode'
+            ], query={
+                'extended': extended
+        })
 
         return SummaryMapper.episode(
             self.client,
@@ -57,21 +66,25 @@ class ShowsInterface(Interface):
             self.get_data(response, **kwargs)
         )
 
-    def season(self, id, season, **kwargs):
+    def season(self, id, season, extended=None, **kwargs):
         response = self.http.get(str(id), [
             'seasons', str(season)
-        ])
+        ], query={
+            'extended': extended
+        })
 
         return SummaryMapper.episodes(
             self.client,
             self.get_data(response, **kwargs)
         )
 
-    def episode(self, id, season, episode, **kwargs):
+    def episode(self, id, season, episode, extended=None, **kwargs):
         response = self.http.get(str(id), [
             'seasons', str(season),
             'episodes', str(episode)
-        ])
+        ], query={
+            'extended': extended
+        })
 
         return SummaryMapper.episode(
             self.client,

--- a/trakt/objects/episode.py
+++ b/trakt/objects/episode.py
@@ -1,4 +1,4 @@
-from trakt.core.helpers import to_iso8601, deprecated
+from trakt.core.helpers import from_iso8601, to_iso8601, deprecated
 from trakt.objects.core.helpers import update_attributes
 from trakt.objects.video import Video
 
@@ -26,6 +26,34 @@ class Episode(Video):
         :type: :class:`~python:str`
 
         Episode title
+        """
+
+        self.overview = None
+        """
+        :type: :class:`~python:str`
+
+        Episode overview
+        """
+
+        self.first_aired = None
+        """
+        :type: :class:`~python:datetime.datetime`
+
+        Air date
+        """
+
+        self.updated_at = None
+        """
+        :type: :class:`~python:datetime.datetime`
+
+        Updated date
+        """
+
+        self.available_translations = None
+        """
+        :type: :class:`~python:list`
+
+        Available translations
         """
 
     def to_identifier(self):
@@ -79,12 +107,30 @@ class Episode(Video):
             result['rating'] = self.rating.value
             result['rated_at'] = to_iso8601(self.rating.timestamp)
 
+        if self.first_aired:
+            result['first_aired'] = to_iso8601(self.first_aired)
+
+        if self.updated_at:
+            result['updated_at'] = to_iso8601(self.updated_at)
+
+        if self.overview:
+            result['overview'] = self.overview
+
+        if self.available_translations:
+            result['available_translations'] = self.available_translations
+
         return result
 
     def _update(self, info=None, **kwargs):
         super(Episode, self)._update(info, **kwargs)
 
-        update_attributes(self, info, ['title'])
+        update_attributes(self, info, ['title', 'overview', 'available_translations'])
+
+        if 'first_aired' in info:
+            self.first_aired = from_iso8601(info.get('first_aired'))
+
+        if 'updated_at' in info:
+            self.updated_at = from_iso8601(info.get('updated_at'))
 
     @classmethod
     def _construct(cls, client, keys, info=None, index=None, **kwargs):

--- a/trakt/objects/show.py
+++ b/trakt/objects/show.py
@@ -1,4 +1,4 @@
-from trakt.core.helpers import to_iso8601, deprecated
+from trakt.core.helpers import from_iso8601, to_iso8601, deprecated
 from trakt.objects.core.helpers import update_attributes
 from trakt.objects.media import Media
 
@@ -38,6 +38,106 @@ class Show(Media):
 
         Number of active watchers (returned by the :code:`Trakt['movies'].trending()`
         and :code:`Trakt['shows'].trending()` methods)
+        """
+
+        self.overview = None
+        """
+        :type: :class:`~python:str`
+
+        Episode overview
+        """
+
+        self.first_aired = None
+        """
+        :type: :class:`~python:datetime.datetime`
+
+        Air date
+        """
+
+        self.airs = None
+        """
+        :type: :class:`~python:dict`
+
+        Dictionary with day, time and timezone in which the show airs
+        """
+
+        self.runtime = None
+        """
+        :type: :class:`~python:int`
+
+        Duration of the show in minutes
+        """
+
+        self.certification = None
+        """
+        :type: :class:`~python:str`
+
+        Show certification (e.g TV-MA)
+        """
+
+        self.network = None
+        """
+        :type: :class:`~python:str`
+
+        Network in which the show is aired
+        """
+
+        self.country = None
+        """
+        :type: :class:`~python:str`
+
+        Country in which the show is aired
+        """
+
+        self.updated_at = None
+        """
+        :type: :class:`~python:datetime.datetime`
+
+        Updated date
+        """
+
+        self.status = None
+        """
+        :type: :class:`~python:str`
+
+        Value of :code:`returning series` (airing right now),
+        :code:`in production` (airing soon), :code:`planned` (in development),
+        :code:`canceled`, or :code:`ended`
+        """
+
+        self.homepage = None
+        """
+        :type: :class:`~python:str`
+
+        Show homepage url
+        """
+
+        self.language = None
+        """
+        :type: :class:`~python:str`
+
+        Show language
+        """
+
+        self.available_translations = None
+        """
+        :type: :class:`~python:list`
+
+        Available translations
+        """
+
+        self.genres = None
+        """
+        :type: :class:`~python:list`
+
+        Show genres
+        """
+
+        self.aired_episodes = None
+        """
+        :type: :class:`~python:int`
+
+        Aired episodes
         """
 
     def episodes(self):
@@ -91,6 +191,48 @@ class Show(Media):
 
         result['in_watchlist'] = self.in_watchlist if self.in_watchlist is not None else 0
 
+        if self.first_aired:
+            result['first_aired'] = to_iso8601(self.first_aired)
+
+        if self.updated_at:
+            result['updated_at'] = to_iso8601(self.updated_at)
+
+        if self.overview:
+            result['overview'] = self.overview
+
+        if self.available_translations:
+            result['available_translations'] = self.available_translations
+
+        if self.airs:
+            result['airs'] = self.airs
+
+        if self.runtime:
+            result['runtime'] = self.runtime
+
+        if self.certification:
+            result['certification'] = self.certification
+
+        if self.network:
+            result['network'] = self.network
+
+        if self.country:
+            result['country'] = self.country
+
+        if self.homepage:
+            result['homepage'] = self.homepage
+
+        if self.status:
+            result['status'] = self.status
+
+        if self.language:
+            result['language'] = self.language
+
+        if self.genres:
+            result['genres'] = self.genres
+
+        if self.aired_episodes:
+            result['aired_episodes'] = self.aired_episodes
+
         return result
 
     def _update(self, info=None, **kwargs):
@@ -99,11 +241,34 @@ class Show(Media):
         update_attributes(self, info, [
             'title',
 
-            'watchers'  # trending
+            'watchers',  # trending
+
+            'overview', # extended info
+            'airs',
+            'certification',
+            'network',
+            'country',
+            'homepage',
+            'status',
+            'language',
+            'available_translations',
+            'genres'
         ])
 
         if info.get('year'):
             self.year = int(info['year'])
+
+        if info.get('runtime'):
+            self.runtime = int(info['runtime'])
+
+        if info.get('aired_episodes'):
+            self.aired_episodes = int(info['aired_episodes'])
+
+        if 'first_aired' in info:
+            self.first_aired = from_iso8601(info.get('first_aired'))
+
+        if 'updated_at' in info:
+            self.updated_at = from_iso8601(info.get('updated_at'))
 
     @classmethod
     def _construct(cls, client, keys, info=None, index=None, **kwargs):


### PR DESCRIPTION
I have added support for extended info in:

- get()
- trending()
- next_episode()
- last_episode()
- season()
- episode()

To check the new info available:

```python
trending = Trakt['shows'].trending(extended='full')
for show in trending:
    print show.to_dict()
```

```python
last = Trakt['shows'].last_episode('id', extended='full')
print last.to_dict()
```