### PR TITLE
Implemented: Remove a playback (progress) item.

### DIFF
--- a/tests/fixtures/sync/playback/delete.json
+++ b/tests/fixtures/sync/playback/delete.json
@@ -1,0 +1,48 @@
+[
+  {
+    "progress": 10,
+    "paused_at": "2015-01-25T22:01:32.000Z",
+    "id": 13,
+    "type": "movie",
+    "movie": {
+      "title": "Batman Begins",
+      "year": 2005,
+      "ids": {
+        "trakt": 1,
+        "slug": "batman-begins-2005",
+        "imdb": "tt0372784",
+        "tmdb": 272
+      }
+    }
+  },
+  {
+    "progress": 65.5,
+    "paused_at": "2015-01-25T22:01:32.000Z",
+    "id": 37,
+    "type": "episode",
+    "episode": {
+      "season": 0,
+      "number": 1,
+      "title": "Good Cop Bad Cop",
+      "ids": {
+        "trakt": 1,
+        "tvdb": 3859781,
+        "imdb": "",
+        "tmdb": 62131,
+        "tvrage": null
+      }
+    },
+    "show": {
+      "title": "Breaking Bad",
+      "year": 2008,
+      "ids": {
+        "trakt": 1,
+        "slug": "breaking-bad",
+        "tvdb": 81189,
+        "imdb": "tt0903747",
+        "tmdb": 1396,
+        "tvrage": 18164
+      }
+    }
+  }
+]

--- a/tests/sync/playback/test_delete.py
+++ b/tests/sync/playback/test_delete.py
@@ -65,8 +65,8 @@ def test_basic():
     )
 
     with Trakt.configuration.auth('mock', 'mock'):
-        success_movie   = Trakt['sync/playback'].delete_progress(13)
-        success_episode = Trakt['sync/playback'].delete_progress(37)
+        success_movie   = Trakt['sync/playback'].delete(13)
+        success_episode = Trakt['sync/playback'].delete(37)
 
     assert success_movie is True
     assert success_episode is True

--- a/tests/sync/playback/test_delete.py
+++ b/tests/sync/playback/test_delete.py
@@ -1,0 +1,72 @@
+from tests.core.helpers import authenticated_response
+
+from datetime import datetime
+from dateutil.tz import tzutc
+from hamcrest import *
+from trakt import Trakt
+from trakt.objects import Movie, Show, Episode
+import responses
+
+
+@responses.activate
+def test_basic():
+    responses.add_callback(
+        responses.GET, 'http://mock/sync/playback',
+        callback=authenticated_response('fixtures/sync/playback/delete.json'),
+        content_type='application/json'
+    )
+
+    Trakt.base_url = 'http://mock'
+
+    with Trakt.configuration.auth('mock', 'mock'):
+        collection = Trakt['sync/playback'].get()
+
+    # Ensure collection is valid
+    assert_that(collection, not_none())
+    
+    # Batman Begins (2005)
+    assert_that(collection[('imdb', 'tt0372784')], has_properties({
+        'id': 13
+    }))
+    
+    # Breaking Bad (2008)
+    assert_that(collection[('tvdb', '81189')], has_properties({
+
+        # Seasons
+        'seasons': all_of(
+            has_length(1),
+
+            # Seasons
+            has_entry(0, has_properties({
+                'episodes': all_of(
+                    has_length(1),
+
+                    # Episodes
+                    has_entry(1, has_properties({
+                        'id': 37
+                    }))
+                )
+            }))
+        ),
+    }))
+
+    # Batman Begins (2005)
+    responses.add_callback(
+        responses.DELETE, 'http://mock/sync/playback/13', # 13 = collection[('imdb', 'tt0372784')].id
+        callback=authenticated_response(data='{"mock": "mock"}'),
+        content_type='application/json'
+    )
+    
+    # Breaking Bad (2008) - S00E01 - Good Cop Bad Cop
+    responses.add_callback(
+        responses.DELETE, 'http://mock/sync/playback/37', # 37 = collection[('tvdb', '81189')].seasons[0].episodes[1].id
+        callback=authenticated_response(data='{"mock": "mock"}'),
+        content_type='application/json'
+    )
+
+    with Trakt.configuration.auth('mock', 'mock'):
+        success_movie   = Trakt['sync/playback'].delete_progress(13)
+        success_episode = Trakt['sync/playback'].delete_progress(37)
+
+    assert success_movie is True
+    assert success_episode is True

--- a/trakt/interfaces/sync/core/mixins.py
+++ b/trakt/interfaces/sync/core/mixins.py
@@ -91,9 +91,9 @@ class Remove(Interface):
 
 class Delete(Interface):
     @authenticated
-    def delete(self, item, **kwargs):
+    def delete(self, playbackid, **kwargs):
         response = self.http.delete(
-            path=str(item),
+            path=str(playbackid),
             **popitems(kwargs, [
                 'authenticated',
                 'validate_token'

--- a/trakt/interfaces/sync/core/mixins.py
+++ b/trakt/interfaces/sync/core/mixins.py
@@ -87,3 +87,17 @@ class Remove(Interface):
         )
 
         return self.get_data(response, **kwargs)
+
+
+class Delete(Interface):
+    @authenticated
+    def delete(self, item, **kwargs):
+        response = self.http.delete(
+            path=str(item),
+            **popitems(kwargs, [
+                'authenticated',
+                'validate_token'
+            ])
+        )
+
+        return 200 <= response.status_code < 300

--- a/trakt/interfaces/sync/playback.py
+++ b/trakt/interfaces/sync/playback.py
@@ -16,10 +16,3 @@ class SyncPlaybackInterface(Get, Delete):
             store,
             **kwargs
         )
-
-    @authenticated
-    def delete_progress(self, playbackid, **kwargs):
-        return self.delete(
-            playbackid,
-            **kwargs
-        )

--- a/trakt/interfaces/sync/playback.py
+++ b/trakt/interfaces/sync/playback.py
@@ -1,8 +1,8 @@
 from trakt.interfaces.base import authenticated
-from trakt.interfaces.sync.core.mixins import Get
+from trakt.interfaces.sync.core.mixins import Get, Delete
 
 
-class SyncPlaybackInterface(Get):
+class SyncPlaybackInterface(Get, Delete):
     path = 'sync/playback'
 
     @authenticated
@@ -14,5 +14,12 @@ class SyncPlaybackInterface(Get):
         return self.get(
             'episodes',
             store,
+            **kwargs
+        )
+
+    @authenticated
+    def delete_progress(self, playbackid, **kwargs):
+        return self.delete(
+            playbackid,
             **kwargs
         )


### PR DESCRIPTION
[recreated #53 from a clean slate]

I noticed that [remove a playback item](http://docs.trakt.apiary.io/#reference/sync/remove-playback/remove-a-playback-item) was not yet implemented, so I implemented it myself.
It might not be the best code or way to accomplish that,
but it's working, and that's something.

Usage is:
~~`Trakt['sync/playback'].delete_progress(pbid)`~~
`Trakt['sync/playback'].delete(pbid)`

**`pbid`** being the playback id you get from `Trakt['sync/playback'].get()`

If improvements are needed, the are very welcome.

P.S. I also made a script to test use this..
https://github.com/sharkykh/TraktPlaybackProgressManager