### PR TITLE
Adding watched and collection progress APIs to shows interface

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,4 +1,5 @@
 Dean Gardiner <me@dgardiner.net>
+Jannon Frank <theoriginal@gmail.com>
 Kolja Lampe <razzeee@gmail.com>
 Lalit Maganti <lalitmaganti@gmail.com>
 Leticia Hernández <leticia.hu@gmail.com>

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ PYTEST_RUNNER = ['pytest-runner>=2.0.0'] if NEEDS_PYTEST else []
 
 setup(
     setup_requires=PYTEST_RUNNER + [
-        'pbr>=1.9',
+        'pbr>=1.9,<=3.1.1',
         'setuptools>=17.1'
     ],
     pbr=True,

--- a/tests/fixtures/api.trakt.tv/shows/1390/progress/watched.json
+++ b/tests/fixtures/api.trakt.tv/shows/1390/progress/watched.json
@@ -1,0 +1,90 @@
+{
+  "aired": 10,
+  "completed": 6,
+  "last_watched_at": "2015-03-21T19:03:58.000Z",
+  "reset_at": "2015-03-21T19:03:58.000Z",
+  "seasons": [
+    {
+      "number": 1,
+      "aired": 8,
+      "completed": 6,
+      "episodes": [
+        {
+          "number": 1,
+          "completed": true,
+          "last_watched_at": "2015-03-21T19:03:58.000Z"
+        },
+        {
+          "number": 2,
+          "completed": true,
+          "last_watched_at": "2015-03-21T19:03:58.000Z"
+        },
+        {
+          "number": 3,
+          "completed": true,
+          "last_watched_at": "2015-03-21T19:03:58.000Z"
+        },
+        {
+          "number": 4,
+          "completed": true,
+          "last_watched_at": "2015-03-21T19:03:58.000Z"
+        },
+        {
+          "number": 5,
+          "completed": true,
+          "last_watched_at": "2015-03-21T19:03:58.000Z"
+        },
+        {
+          "number": 6,
+          "completed": true,
+          "last_watched_at": "2015-03-21T19:03:58.000Z"
+        },
+        {
+          "number": 7,
+          "completed": false,
+          "last_watched_at": null
+        },
+        {
+          "number": 8,
+          "completed": false,
+          "last_watched_at": null
+        },
+        {
+          "number": 9,
+          "completed": false,
+          "last_watched_at": null
+        },
+        {
+          "number": 10,
+          "completed": false,
+          "last_watched_at": null
+        }
+      ]
+    }
+  ],
+  "hidden_seasons": [],
+  "next_episode": {
+    "season": 1,
+    "number": 7,
+    "title": "You Win or You Die",
+    "ids": {
+      "trakt": 73646,
+      "tvdb": 3436461,
+      "imdb": "tt1837863",
+      "tmdb": 63062,
+      "tvrage": 1065036404
+    }
+  },
+  "last_episode": {
+    "season": 1,
+    "number": 5,
+    "title": "You Die and You Win",
+    "ids": {
+      "trakt": 73646,
+      "tvdb": 3436461,
+      "imdb": "tt1837863",
+      "tmdb": 63062,
+      "tvrage": 1065036404
+    }
+  }
+}

--- a/tests/fixtures/api.trakt.tv/shows/game-of-thrones/progress/watched.json
+++ b/tests/fixtures/api.trakt.tv/shows/game-of-thrones/progress/watched.json
@@ -1,0 +1,87 @@
+{
+  "aired": 10,
+  "completed": 6,
+  "last_watched_at": "2015-03-21T19:03:58.000Z",
+  "reset_at": null,
+  "seasons": [
+    {
+      "number": 1,
+      "aired": 8,
+      "completed": 6,
+      "episodes": [
+        {
+          "number": 1,
+          "completed": true,
+          "last_watched_at": "2015-03-21T19:03:58.000Z"
+        },
+        {
+          "number": 2,
+          "completed": true,
+          "last_watched_at": "2015-03-21T19:03:58.000Z"
+        },
+        {
+          "number": 3,
+          "completed": true,
+          "last_watched_at": "2015-03-21T19:03:58.000Z"
+        },
+        {
+          "number": 4,
+          "completed": true,
+          "last_watched_at": "2015-03-21T19:03:58.000Z"
+        },
+        {
+          "number": 5,
+          "completed": true,
+          "last_watched_at": "2015-03-21T19:03:58.000Z"
+        },
+        {
+          "number": 6,
+          "completed": true,
+          "last_watched_at": "2015-03-21T19:03:58.000Z"
+        },
+        {
+          "number": 7,
+          "completed": false,
+          "last_watched_at": null
+        },
+        {
+          "number": 8,
+          "completed": false,
+          "last_watched_at": null
+        },
+        {
+          "number": 9,
+          "completed": false,
+          "last_watched_at": null
+        },
+        {
+          "number": 10,
+          "completed": false,
+          "last_watched_at": null
+        }
+      ]
+    }
+  ],
+  "hidden_seasons": [
+    {
+      "number": 2,
+      "ids": {
+        "trakt": 3051,
+        "tvdb": 498968,
+        "tmdb": 53334
+      }
+    }
+  ],
+  "next_episode": {
+    "season": 1,
+    "number": 7,
+    "title": "You Win or You Die",
+    "ids": {
+      "trakt": 73646,
+      "tvdb": 3436461,
+      "imdb": "tt1837863",
+      "tmdb": 63062,
+      "tvrage": 1065036404
+    }
+  }
+}

--- a/tests/oauth/test_oauth.py
+++ b/tests/oauth/test_oauth.py
@@ -38,16 +38,16 @@ def test_authorize_url():
 
 def test_pin_url():
     with Trakt.configuration.app(id=1234):
-        assert_url(Trakt['oauth'].pin_url(), '/pin/1234')
+        assert_url(Trakt['oauth/pin'].url(), '/pin/1234')
 
     with pytest.raises(ValueError):
-        Trakt['oauth'].pin_url()
+        Trakt['oauth/pin'].url()
 
 
 def test_token():
     with HTTMock(mock.oauth_token, mock.unknown):
         # Validate `token_exchange` request/response
-        assert Trakt['oauth'].token('ABCD1234', 'urn:ietf:wg:oauth:2.0:oob') == {
+        assert Trakt['oauth'].token_exchange('ABCD1234', 'urn:ietf:wg:oauth:2.0:oob') == {
             'access_token': 'mock-access_token',
             'token_type': 'bearer',
             'expires_in': 7200,
@@ -57,7 +57,7 @@ def test_token():
 
         # Ensure `token_exchange` raises a `ValueError` on incorrect configuration
         with pytest.raises(ValueError):
-            assert TraktClient()['oauth'].token('ABCD1234', 'urn:ietf:wg:oauth:2.0:oob')
+            assert TraktClient()['oauth'].token_exchange('ABCD1234', 'urn:ietf:wg:oauth:2.0:oob')
 
 
 def test_token_exchange():

--- a/tests/test_progress.py
+++ b/tests/test_progress.py
@@ -1,0 +1,142 @@
+from __future__ import absolute_import, division, print_function
+
+from tests.core import mock
+from trakt import Trakt
+
+from hamcrest import assert_that, has_entries
+from httmock import HTTMock
+
+
+def test_watched_progress():
+    with HTTMock(mock.fixtures, mock.unknown):
+        with Trakt.configuration.auth('mock', 'mock'):
+            progress = Trakt['shows'].watched_progress(1390)
+
+    assert progress is not None
+    assert progress.reset_at is not None
+    assert progress.last_progress_change is not None
+    assert progress.aired == 10
+    assert progress.completed == 6
+
+    assert len(progress.seasons) == 1
+    assert progress.seasons[1].aired == 8
+    assert progress.seasons[1].completed == 6
+
+    assert len(progress.seasons[1].episodes) == 10
+    assert progress.seasons[1].episodes[1].progress_timestamp is not None
+
+    assert len(progress.hidden_seasons) == 0
+
+    assert progress.next_episode.pk == (1, 7)
+    assert progress.last_episode.pk == (1, 5)
+
+
+def test_watched_progress_plus_hidden():
+    with HTTMock(mock.fixtures, mock.unknown):
+        with Trakt.configuration.auth('mock', 'mock'):
+            progress = Trakt['shows'].watched_progress('game-of-thrones', hidden=True)
+
+    assert progress is not None
+    assert progress.reset_at is None
+
+    assert len(progress.hidden_seasons) == 1
+
+    assert_that(progress.to_dict(), has_entries({
+        'aired': 10,
+        'completed': 6,
+        'last_watched_at': '2015-03-21T19:03:58.000-00:00',
+        'reset_at': None,
+        'seasons': [
+            {
+                'number': 1,
+                'aired': 8,
+                'completed': 6,
+                'episodes': [
+                    {
+                        'number': 1,
+                        'completed': True,
+                        'last_watched_at': '2015-03-21T19:03:58.000-00:00'
+                    },
+                    {
+                        'number': 2,
+                        'completed': True,
+                        'last_watched_at': '2015-03-21T19:03:58.000-00:00'
+                    },
+                    {
+                        'number': 3,
+                        'completed': True,
+                        'last_watched_at': '2015-03-21T19:03:58.000-00:00'
+                    },
+                    {
+                        'number': 4,
+                        'completed': True,
+                        'last_watched_at': '2015-03-21T19:03:58.000-00:00'
+                    },
+                    {
+                        'number': 5,
+                        'completed': True,
+                        'last_watched_at': '2015-03-21T19:03:58.000-00:00'
+                    },
+                    {
+                        'number': 6,
+                        'completed': True,
+                        'last_watched_at': '2015-03-21T19:03:58.000-00:00'
+                    },
+                    {
+                        'number': 7,
+                        'completed': False,
+                        'last_watched_at': None
+                    },
+                    {
+                        'number': 8,
+                        'completed': False,
+                        'last_watched_at': None
+                    },
+                    {
+                        'number': 9,
+                        'completed': False,
+                        'last_watched_at': None
+                    },
+                    {
+                        'number': 10,
+                        'completed': False,
+                        'last_watched_at': None
+                    }
+                ]
+            }
+        ],
+        'hidden_seasons': [
+            {
+                'number': 2,
+                'ids': {
+                    'trakt': '3051',
+                    'tvdb': '498968',
+                    'tmdb': '53334'
+                }
+            }
+        ],
+        'next_episode': {
+            'season': 1,
+            'number': 7,
+            'title': 'You Win or You Die',
+            'ids': {
+                'trakt': '73646',
+                'tvdb': '3436461',
+                'imdb': 'tt1837863',
+                'tmdb': '63062',
+                'tvrage': '1065036404'
+            }
+        }
+    }))
+
+
+def test_collection_progress():
+    with HTTMock(mock.fixtures, mock.unknown):
+        with Trakt.configuration.auth('mock', 'mock'):
+            progress = Trakt['shows'].collection_progress(1390)
+
+    assert progress is not None
+    assert progress.reset_at is None
+    assert progress.last_progress_change is not None
+
+    assert progress.seasons[1].episodes[1].progress_timestamp is not None

--- a/tox.ini
+++ b/tox.ini
@@ -34,7 +34,7 @@ deps =
   flake8-bugbear>=17.3.0
   flake8-docstrings>=0.2.7
   flake8-future-import>=0.4.3
-  flake8-import-order>=0.9
+  flake8-import-order>=0.9,<=0.16
   flake8-import-order-fuzeman>=1.1.1
   flake8-quotes>=0.9.0
 commands =

--- a/trakt/core/emitter.py
+++ b/trakt/core/emitter.py
@@ -178,7 +178,7 @@ class Emitter(object):
             callback(*args, **kwargs)
             return True
         except Exception as ex:
-            log.warn('[%s] Exception raised in: %s - %s' % (event, cls.__function_name(callback), ex), exc_info=True)
+            log.warning('[%s] Exception raised in: %s - %s' % (event, cls.__function_name(callback), ex), exc_info=True)
             return False
 
     def __call_async(self, callback, args=None, kwargs=None, event=None):

--- a/trakt/core/errors.py
+++ b/trakt/core/errors.py
@@ -42,7 +42,7 @@ def log_request_error(logger, response):
         message = 'Request failed: %s: "%%s" (%%s)' % (response.status_code,)
 
     # Log warning
-    logger.warn(message, desc, name, extra={
+    logger.warning(message, desc, name, extra={
         'data': {
             'http.headers': {
                 'cf-ray': response.headers.get('cf-ray'),

--- a/trakt/core/http.py
+++ b/trakt/core/http.py
@@ -125,7 +125,7 @@ class HttpClient(object):
 
         for i in range(max_retries + 1):
             if i > 0:
-                log.warn('Retry # %s', i)
+                log.warning('Retry # %s', i)
 
             exc_info = None
 
@@ -140,7 +140,7 @@ class HttpClient(object):
                 if code != 8:
                     raise e
 
-                log.warn('Encountered socket.gaierror (code: 8)')
+                log.warning('Encountered socket.gaierror (code: 8)')
 
                 response = self.rebuild().send(request, timeout=timeout)
 
@@ -149,12 +149,12 @@ class HttpClient(object):
                 break
 
             if exc_info:
-                log.warn(
+                log.warning(
                     'Continue retry since "%s" exception was raised, waiting %s seconds',
                     exc_info[0].__name__, retry_sleep
                 )
             else:
-                log.warn(
+                log.warning(
                     'Continue retry since status is %s, waiting %s seconds',
                     response.status_code, retry_sleep
                 )
@@ -243,11 +243,11 @@ class HttpClient(object):
             return True
 
         if not config['oauth.refresh']:
-            log.warn('OAuth - Unable to refresh expired token (token refreshing hasn\'t been enabled)')
+            log.warning('OAuth - Unable to refresh expired token (token refreshing hasn\'t been enabled)')
             return False
 
         if not config['oauth.refresh_token']:
-            log.warn('OAuth - Unable to refresh expired token ("refresh_token" parameter hasn\'t been defined)')
+            log.warning('OAuth - Unable to refresh expired token ("refresh_token" parameter hasn\'t been defined)')
             return False
 
         # Retrieve username
@@ -258,7 +258,7 @@ class HttpClient(object):
 
         # Acquire refreshing lock
         if not self._oauth_refreshing[username].acquire(False):
-            log.warn('OAuth - Token is already being refreshed for %r', username)
+            log.warning('OAuth - Token is already being refreshed for %r', username)
             return False
 
         log.info('OAuth - Token has expired, refreshing token...')
@@ -284,7 +284,7 @@ class HttpClient(object):
         )
 
         if response is None:
-            log.warn('OAuth - Unable to refresh expired token (no response returned)')
+            log.warning('OAuth - Unable to refresh expired token (no response returned)')
             return False
 
         if response.status_code < 200 or response.status_code >= 300:
@@ -293,14 +293,14 @@ class HttpClient(object):
 
             # Handle refresh rejection
             if response.status_code == 401:
-                log.warn('OAuth - Unable to refresh expired token (rejected)')
+                log.warning('OAuth - Unable to refresh expired token (rejected)')
 
                 # Fire rejected event
                 self.client.emit('oauth.refresh.rejected', config['oauth.username'])
                 return False
 
             # Unknown error returned
-            log.warn('OAuth - Unable to refresh expired token (code: %r)', response.status_code)
+            log.warning('OAuth - Unable to refresh expired token (code: %r)', response.status_code)
             return False
 
         # Retrieve authorization parameters from response

--- a/trakt/core/pagination.py
+++ b/trakt/core/pagination.py
@@ -54,7 +54,7 @@ class PaginationIterator(object):
         response = self.fetch(page)
 
         if response is None:
-            log.warn('Request failed (no response returned)')
+            log.warning('Request failed (no response returned)')
             return None
 
         if response.status_code < 200 or response.status_code >= 300:

--- a/trakt/interfaces/base/__init__.py
+++ b/trakt/interfaces/base/__init__.py
@@ -64,7 +64,7 @@ class Interface(object):
             if exceptions:
                 raise RequestFailedError('No response available')
 
-            log.warn('Request failed (no response returned)')
+            log.warning('Request failed (no response returned)')
             return None
 
         # Return response, if parse=False

--- a/trakt/interfaces/oauth/device.py
+++ b/trakt/interfaces/oauth/device.py
@@ -116,7 +116,7 @@ class DeviceOAuthPoller(Interface, Emitter):
             try:
                 self._process()
             except Exception as ex:
-                log.warn('Exception raised in DeviceOAuthPoller: %s', ex, exc_info=True)
+                log.warning('Exception raised in DeviceOAuthPoller: %s', ex, exc_info=True)
             finally:
                 self._active = False
                 self._running = False

--- a/trakt/interfaces/shows/__init__.py
+++ b/trakt/interfaces/shows/__init__.py
@@ -1,6 +1,8 @@
 from __future__ import absolute_import, division, print_function
 
-from trakt.interfaces.base import Interface
+from trakt.core.helpers import popitems
+from trakt.interfaces.base import Interface, authenticated
+from trakt.mapper.progress import ProgressMapper
 from trakt.mapper.summary import SummaryMapper
 
 import requests
@@ -99,3 +101,34 @@ class ShowsInterface(Interface):
             return item
 
         return SummaryMapper.episode(self.client, item)
+
+    @authenticated
+    def watched_progress(self, id, hidden=False, specials=False, count_specials=True, **kwargs):
+        return self.progress('watched', id, hidden, specials, count_specials, **kwargs)
+
+    @authenticated
+    def collection_progress(self, id, hidden=False, specials=False, count_specials=True, **kwargs):
+        return self.progress('collection', id, hidden, specials, count_specials, **kwargs)
+
+    @authenticated
+    def progress(self, progress_type, id, hidden=False, specials=False, count_specials=True, **kwargs):
+        query = {
+            'hidden': hidden,
+            'specials': specials,
+            'count_specials': count_specials
+        }
+
+        response = self.http.get(str(id),
+                                 ['progress', progress_type],
+                                 query=query,
+                                 **popitems(kwargs, [
+                                     'authenticated',
+                                     'validate_token'
+                                 ]))
+
+        item = self.get_data(response, **kwargs)
+
+        if isinstance(item, requests.Response):
+            return item
+
+        return ProgressMapper.progress(self.client, progress_type, item)

--- a/trakt/interfaces/users/__init__.py
+++ b/trakt/interfaces/users/__init__.py
@@ -58,4 +58,4 @@ class UsersInterface(Interface):
                     self.client, item
                 )
             else:
-                log.warn('Unknown item returned, type: %r', item_type)
+                log.warning('Unknown item returned, type: %r', item_type)

--- a/trakt/mapper/__init__.py
+++ b/trakt/mapper/__init__.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import, division, print_function
 from trakt.mapper.comment import CommentMapper
 from trakt.mapper.list import ListMapper
 from trakt.mapper.list_item import ListItemMapper
+from trakt.mapper.progress import ProgressMapper
 from trakt.mapper.search import SearchMapper
 from trakt.mapper.summary import SummaryMapper
 from trakt.mapper.sync import SyncMapper
@@ -12,6 +13,7 @@ __all__ = (
     'CommentMapper',
     'ListMapper',
     'ListItemMapper',
+    'ProgressMapper',
     'SearchMapper',
     'SummaryMapper',
     'SyncMapper'

--- a/trakt/mapper/core/base.py
+++ b/trakt/mapper/core/base.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import, division, print_function
 
-from trakt.objects import Movie, Show, Episode, Season, CustomList, Comment, Person
+from trakt.objects import Movie, Show, Episode, Season, CustomList, Comment, Person, WatchedProgress, CollectionProgress
 
 IDENTIFIERS = {
     'movie': [
@@ -114,5 +114,11 @@ class Mapper(object):
 
         if media == 'person':
             return Person._construct(client, keys, item, **kwargs)
+
+        if media == 'watched_progress':
+            return WatchedProgress._construct(client, item, **kwargs)
+
+        if media == 'collection_progress':
+            return CollectionProgress._construct(client, item, **kwargs)
 
         raise ValueError('Unknown media type provided')

--- a/trakt/mapper/progress.py
+++ b/trakt/mapper/progress.py
@@ -1,0 +1,24 @@
+from __future__ import absolute_import, division, print_function
+
+from trakt.mapper.core.base import Mapper
+
+
+class ProgressMapper(Mapper):
+    @classmethod
+    def progress(cls, client, progress_type, item, **kwargs):
+        if not item:
+            return None
+
+        if 'progress' in item:
+            i_progress = item['progress']
+        else:
+            i_progress = item
+
+        # Create object
+        progress = cls.construct(client, '%s_progress' % progress_type, i_progress, **kwargs)
+
+        # Update with root info
+        if 'progress' in item:
+            progress._update(item)
+
+        return progress

--- a/trakt/mapper/search.py
+++ b/trakt/mapper/search.py
@@ -15,14 +15,14 @@ class SearchMapper(Mapper):
             media = item.get('type')
 
         if not media:
-            log.warn('Item %r has no "type" defined', media)
+            log.warning('Item %r has no "type" defined', media)
             return None
 
         # Find function for `media`
         func = getattr(cls, media, None)
 
         if not func:
-            log.warn('Unknown media type: %r', media)
+            log.warning('Unknown media type: %r', media)
             return None
 
         # Map item

--- a/trakt/mapper/sync.py
+++ b/trakt/mapper/sync.py
@@ -201,7 +201,7 @@ class SyncMapper(Mapper):
             )
 
             if result is None:
-                log.warn('Unable to map item: %s', item)
+                log.warning('Unable to map item: %s', item)
 
         return store
 
@@ -244,7 +244,7 @@ class SyncMapper(Mapper):
             )
 
             if result is None:
-                log.warn('Unable to map item: %s', item)
+                log.warning('Unable to map item: %s', item)
 
             # Yield item in iterator
             yield result

--- a/trakt/objects/__init__.py
+++ b/trakt/objects/__init__.py
@@ -6,6 +6,7 @@ from trakt.objects.list import CustomList, List
 from trakt.objects.media import Media
 from trakt.objects.movie import Movie
 from trakt.objects.person import Person
+from trakt.objects.progress import CollectionProgress, WatchedProgress
 from trakt.objects.rating import Rating
 from trakt.objects.season import Season
 from trakt.objects.show import Show
@@ -22,5 +23,6 @@ __all__ = (
     'Season',
     'Show',
     'Video',
-    'Person'
+    'Person',
+    'WatchedProgress', 'CollectionProgress'
 )

--- a/trakt/objects/progress.py
+++ b/trakt/objects/progress.py
@@ -1,0 +1,322 @@
+from __future__ import absolute_import, division, print_function
+
+from trakt.core.helpers import from_iso8601_datetime, popitems, to_iso8601_datetime
+from trakt.objects.core.helpers import update_attributes
+from trakt.objects.episode import Episode
+from trakt.objects.season import Season
+
+LABELS = {
+    'last_progress_change': {
+        'watched': 'last_watched_at',
+        'collection': 'last_collected_at'
+    },
+    'episode_progress_change': {
+        'watched': 'last_watched_at',
+        'collection': 'collected_at'
+    }
+}
+
+
+class BaseProgress(object):
+    def __init__(self, aired=None, completed=None):
+        self.aired = aired
+        """
+        :type: :class:`~python:int`
+
+        Number of aired episodes
+        """
+
+        self.completed = completed
+        """
+        :type: :class:`~python:int`
+
+        Number of completed episodes
+        """
+
+    def to_dict(self):
+        return {
+            'aired': self.aired,
+            'completed': self.completed
+        }
+
+    def _update(self, info=None, **kwargs):
+        if not info:
+            return
+
+        update_attributes(self, info, [
+            'aired',
+            'completed'
+        ])
+
+    def __repr__(self):
+        return '%d/%d episodes completed' % (self.completed, self.aired)
+
+
+class Progress(BaseProgress):
+    def __init__(self, client, progress_type, aired=None, completed=None):
+        super(Progress, self).__init__(aired, completed)
+
+        self._client = client
+
+        self.progress_type = progress_type
+        """
+        :type: :class:`~python:str`
+
+        Progress Type (:code:`watched` or :code:`collection`)
+        """
+
+        self.last_progress_change = None
+        """
+        :type: :class:`~python:datetime.datetime`
+
+        Last watched or collected date/time
+        """
+
+        self.reset_at = None
+        """
+        :type: :class:`~python:datetime.datetime`
+
+        Reset date/time (not applicable for collected progress)
+        """
+
+        self.seasons = {}
+        """
+        :type: :class:`~python:dict`
+
+        Season Progress, defined as :code:`{season_num: SeasonProgress}`
+        """
+
+        self.hidden_seasons = None
+        """
+        :type: :class:`~python:dict`
+
+        Hidden Seasons, defined as :code:`{season_num: Season}`
+        """
+
+        self.next_episode = None
+        """
+        :type: :class:`trakt.objects.episode.Episode`
+
+        Next Episode the user should watch or collect
+        """
+
+        self.last_episode = None
+        """
+        :type: :class:`trakt.objects.episode.Episode`
+
+        Last Episode the user watched or collected
+        """
+
+    def to_dict(self):
+        """Dump progress to a dictionary.
+
+        :return: Progress dictionary
+        :rtype: :class:`~python:dict`
+        """
+
+        result = super(Progress, self).to_dict()
+
+        label = LABELS['last_progress_change'][self.progress_type]
+        result[label] = to_iso8601_datetime(self.last_progress_change)
+
+        if self.progress_type == 'watched':
+            result['reset_at'] = self.reset_at
+
+        result['seasons'] = [
+            season.to_dict()
+            for season in self.seasons.values()
+        ]
+
+        if self.hidden_seasons:
+            result['hidden_seasons'] = [
+                popitems(season.to_dict(), ['number', 'ids'])
+                for season in self.hidden_seasons.values()
+            ]
+
+        if self.next_episode:
+            result['next_episode'] = popitems(self.next_episode.to_dict(), ['season', 'number', 'title', 'ids'])
+            result['next_episode']['season'] = self.next_episode.keys[0][0]
+
+        if self.last_episode:
+            result['last_episode'] = popitems(self.last_episode.to_dict(), ['season', 'number', 'title', 'ids'])
+            result['last_episode']['season'] = self.last_episode.keys[0][0]
+
+        return result
+
+    def _update(self, info=None, **kwargs):
+        if not info:
+            return
+
+        super(Progress, self)._update(info, **kwargs)
+
+        label = LABELS['last_progress_change'][self.progress_type]
+        if label in info:
+            self.last_progress_change = from_iso8601_datetime(info.get(label))
+
+        if 'reset_at' in info:
+            self.reset_at = from_iso8601_datetime(info.get('reset_at'))
+
+        if 'seasons' in info:
+            for season in info['seasons']:
+                season_progress = SeasonProgress._construct(season, progress_type=self.progress_type)
+                if season_progress:
+                    self.seasons[season_progress.pk] = season_progress
+
+        if 'hidden_seasons' in info:
+            self.hidden_seasons = {}
+            from trakt.mapper import ProgressMapper
+            for season in info['hidden_seasons']:
+                _, keys = ProgressMapper.get_ids('season', season)
+                hidden_season = Season._construct(self._client, keys, season)
+                if hidden_season:
+                    self.hidden_seasons[hidden_season.pk] = hidden_season
+
+        if 'next_episode' in info:
+            from trakt.mapper import ProgressMapper
+            _, keys = ProgressMapper.get_ids('episode', info['next_episode'])
+            episode = Episode._construct(self._client, keys, info['next_episode'])
+            if episode:
+                self.next_episode = episode
+
+        if 'last_episode' in info:
+            _, keys = ProgressMapper.get_ids('episode', info['last_episode'])
+            episode = Episode._construct(self._client, keys, info['last_episode'])
+            if episode:
+                self.last_episode = episode
+
+    @classmethod
+    def _construct(cls, client, info=None, **kwargs):
+        if not info:
+            return
+
+        progress = cls(client)
+        progress._update(info, **kwargs)
+
+        return progress
+
+
+class WatchedProgress(Progress):
+    def __init__(self, client):
+        super(WatchedProgress, self).__init__(client, 'watched')
+
+
+class CollectionProgress(Progress):
+    def __init__(self, client):
+        super(CollectionProgress, self).__init__(client, 'collection')
+
+
+class SeasonProgress(BaseProgress):
+    def __init__(self, pk=None, aired=None, completed=None):
+        super(SeasonProgress, self).__init__(aired, completed)
+
+        self.pk = pk
+        """
+        :type: :class:`~python:int`
+
+        Season Number
+        """
+
+        self.episodes = {}
+        """
+        :type: :class:`~python:dict`
+
+        Episode Progress, defined as :code:`{episode_num: EpisodeProgress}`
+        """
+
+    def to_dict(self):
+        result = super(SeasonProgress, self).to_dict()
+
+        result['number'] = self.pk
+        result['episodes'] = [
+            episode.to_dict()
+            for episode in self.episodes.values()
+        ]
+        return result
+
+    def _update(self, info=None, **kwargs):
+        if not info:
+            return
+
+        super(SeasonProgress, self)._update(info, **kwargs)
+
+        self.pk = info['number']
+        if 'episodes' in info:
+            for episode in info['episodes']:
+                episode_progress = EpisodeProgress._construct(episode, **kwargs)
+                if episode_progress:
+                    self.episodes[episode_progress.pk] = episode_progress
+
+    @classmethod
+    def _construct(cls, info=None, **kwargs):
+        if not info:
+            return
+
+        season_progress = cls()
+        season_progress._update(info, **kwargs)
+
+        return season_progress
+
+
+class EpisodeProgress(object):
+    def __init__(self, pk=None):
+        self.progress_type = None
+
+        self.pk = pk
+        """
+        :type: :class:`~python:int`
+
+        Episode Number
+        """
+
+        self.completed = None
+        """
+        :type: :class:`~python:bool`
+
+        Whether or not the episode has been watched or collected
+        """
+
+        self.progress_timestamp = None
+        """
+        :type: :class:`~python:datetime.datetime`
+
+        Date/time episode was collected or last watched
+        """
+
+    def to_dict(self):
+        result = {
+            'number': self.pk,
+            'completed': self.completed if self.completed is not None else 0
+        }
+
+        if self.progress_type:
+            label = LABELS['episode_progress_change'][self.progress_type]
+        else:
+            label = 'progress_timestamp'
+        result[label] = to_iso8601_datetime(self.progress_timestamp)
+
+        return result
+
+    def _update(self, info=None, **kwargs):
+        if not info:
+            return
+
+        self.pk = info['number']
+        if 'progress_type' in kwargs:
+            self.progress_type = kwargs['progress_type']
+
+        self.completed = info['completed']
+
+        if 'last_watched_at' in info:
+            self.progress_timestamp = from_iso8601_datetime(info.get('last_watched_at'))
+        elif 'collected_at' in info:
+            self.progress_timestamp = from_iso8601_datetime(info.get('collected_at'))
+
+    @classmethod
+    def _construct(cls, info=None, **kwargs):
+        if not info:
+            return
+
+        episode_progress = cls()
+        episode_progress._update(info, **kwargs)
+
+        return episode_progress


### PR DESCRIPTION
### Overview
I needed this for a project I'm working on.  It also addresses #58. 
This PR does the following:

- adds the Trakt [collection progress](https://trakt.docs.apiary.io/#reference/shows/collection-progress/get-show-collection-progress) and [watched progress](https://trakt.docs.apiary.io/#reference/shows/watched-progress/get-show-watched-progress) APIs to the `Trakt['shows']` interface
- adds tests for the new functionality (even giving a 1% bump to coverage)
- cleans up the deprecation warnings on python3 for use of `log.warn` vs `log.warning`
- caps versions for `pbr` and `flake8-import-order` because more recent versions break install and tests, respectively

### New API Detail
The Trakt progress APIs themselves don't really fit neatly into the model design of the rest of the API so, accordingly, there's not a super-elegant-make-you-feel-all-warm-and-fuzzy way to design this (at least not that I found in the few hours I spent on it), but the interface is straightforward.

There are two new methods:
``` python
Trakt['shows'].watched_progress(id, hidden=False, specials=False, count_specials=True, **kwargs)
Trakt['shows'].collection_progress(id, hidden=False, specials=False, count_specials=True, **kwargs)
```
Both methods return `Progress` objects that encapsulate the data returned from the API.
```
Progress
    aired: int
    completed: int
    last_progress_change: datetime
    reset_at: datetime
    seasons: {season_num: SeasonProgress}
    hidden_seasons: {season_num: Season}
    next_episode: Episode
    last_episode: Episode

SeasonProgress
    aired: int
    completed: int
    pk: int
    episodes: {episode_num: EpisodeProgress}

EpisodeProgress
    pk: int
    completed: boolean
    progress_timestamp: datetime
```
