### PR TITLE
Update arrow compatibility and travis-ci build environment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,14 @@
-dist: trusty
+dist: xenial
 sudo: false
 language: python
 python:
   - 2.7
-  - 3.6
-  - pypy-5.4.1
+  - 3.7
+  - pypy2.7-6.0
   - pypy3.5
-  - 3.4
+  - pypy3.6-7.1.1
   - 3.5
+  - 3.6
   - nightly
 install:
   - travis_retry pip install -r travis-requirements.txt
@@ -25,7 +26,7 @@ deploy:
     file_glob: true
     file: "dist/trakt.py-*"
     on:
-      condition: $TRAVIS_PYTHON_VERSION = "3.6"
+      condition: $TRAVIS_PYTHON_VERSION = "3.7"
       repo: fuzeman/trakt.py
       tags: true
   - provider: pypi
@@ -35,6 +36,6 @@ deploy:
       secure: FaZa7IRrF+tsJ+8tZ19olfu+GW3kfAuXLzePjzA8SFIukDWhi4zi2hpiDOsq5M3f/UouAAB0Nr8fsP1339d9aznQwGm+8CBLgBg0NpffGrcqpegSsf0Phw47R8q4fYz0bXPM1P8okOVpN6Dk9DVOarpygxS3amRROLQpbBYwDOI=
     skip_cleanup: true
     on:
-      condition: $TRAVIS_PYTHON_VERSION = "3.6"
+      condition: $TRAVIS_PYTHON_VERSION = "3.7"
       repo: fuzeman/trakt.py
       tags: true

--- a/examples/search.py
+++ b/examples/search.py
@@ -10,7 +10,7 @@ logging.basicConfig(level=logging.DEBUG)
 
 
 def print_lookup(id, service):
-    print('Trakt[\'search\'].lookup(%r, %r)' % (id, service))
+    print("Trakt['search'].lookup(%r, %r)" % (id, service))
 
     item = Trakt['search'].lookup(id, service)
 
@@ -22,7 +22,7 @@ def print_lookup(id, service):
 
 
 def print_query(query, media=None, year=None):
-    print('Trakt[\'search\'].query(%r, %r, %r)' % (query, media, year))
+    print("Trakt['search'].query(%r, %r, %r)" % (query, media, year))
 
     items = Trakt['search'].query(query, media, year)
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,9 +17,9 @@ classifier =
     Programming Language :: Python :: 2
     Programming Language :: Python :: 2.7
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.4
     Programming Language :: Python :: 3.5
     Programming Language :: Python :: 3.6
+    Programming Language :: Python :: 3.7
     Programming Language :: Python :: Implementation :: CPython
     Programming Language :: Python :: Implementation :: PyPy
     Topic :: Software Development :: Libraries

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,11 @@
 [tox]
-envlist = clean,py27,py34,py35,py36,pypy,stats,flake8
+envlist = clean,py27,py35,py36,py37,pypy,stats,flake8
 minversion = 1.6
 skipsdist = True
 
 [travis]
 python =
-  3.6: py36, flake8
+  3.7: py37, flake8
 
 [testenv]
 deps =
@@ -14,7 +14,7 @@ deps =
 
   pytest-cov>=2.1.0, <3.0.0
 commands =
-  py.test --cov-config .coveragerc --cov-append --cov=trakt
+  py.test --cov-config .coveragerc --cov-append --cov=trakt -W ignore::arrow.factory.ArrowParseWarning
 
 [testenv:clean]
 skip_install = true
@@ -27,7 +27,7 @@ commands =
 commands = sphinx-build -a -b html docs build/sphinx
 
 [testenv:flake8]
-basepython = python3.6
+basepython = python3.7
 skip_install = true
 deps =
   flake8
@@ -67,7 +67,8 @@ ignore =
   FI14,FI54,
   FI15,FI55,
   FI16,
-  FI17
+  FI17,
+  FI18
 exclude =
   .git,
   .tox,

--- a/trakt/core/helpers.py
+++ b/trakt/core/helpers.py
@@ -7,6 +7,8 @@ import warnings
 
 try:
     import arrow
+    from arrow.factory import ArrowParseWarning
+    warnings.simplefilter('ignore', ArrowParseWarning)
 except ImportError:
     arrow = None
 

--- a/trakt/core/http.py
+++ b/trakt/core/http.py
@@ -243,7 +243,7 @@ class HttpClient(object):
             return True
 
         if not config['oauth.refresh']:
-            log.warning('OAuth - Unable to refresh expired token (token refreshing hasn\'t been enabled)')
+            log.warning("OAuth - Unable to refresh expired token (token refreshing hasn't been enabled)")
             return False
 
         if not config['oauth.refresh_token']:

--- a/trakt/interfaces/users/__init__.py
+++ b/trakt/interfaces/users/__init__.py
@@ -27,7 +27,7 @@ class UsersInterface(Interface):
             raise ValueError('Unknown type specified: %r' % type)
 
         if kwargs.get('parse') is False:
-            raise ValueError('Parse can\'t be disabled on this method')
+            raise ValueError("Parse can't be disabled on this method")
 
         # Send request
         response = self.http.get(

--- a/trakt/interfaces/users/lists/__init__.py
+++ b/trakt/interfaces/users/lists/__init__.py
@@ -59,7 +59,7 @@ class UsersListsInterface(Interface):
 
     def get(self, username, **kwargs):
         if kwargs.get('parse') is False:
-            raise ValueError('Parse can\'t be disabled on this method')
+            raise ValueError("Parse can't be disabled on this method")
 
         # Send request
         response = self.http.get(


### PR DESCRIPTION
This PR originated from a desire to remove new warnings that recent updates in the Arrow package have started producing regarding `.get()` usage with strings, but when I went to open a PR, I found that travis-ci had more to say on the matter (e.g. arrow no longer supports python 3.4 and there are new flake8 errors) so I've included changes to resolve those build issues as well

### Arrow Warnings
The arrow changes are discussed here:  [Upcoming changes in version 0.15.0](https://github.com/crsmithdev/arrow/issues/612)

It can generate a lot of text:
```
  ArrowParseWarning,
/Users/user/VE/myenv/lib/python3.7/site-packages/arrow/factory.py:202: ArrowParseWarning: The .get() parsing method without a format string will parse more strictly in version 0.15.0.See https://github.com/crsmithdev/arrow/issues/612 for more details.
  ArrowParseWarning,
/Users/user/VE/myenv/lib/python3.7/site-packages/arrow/factory.py:202: ArrowParseWarning: The .get() parsing method without a format string will parse more strictly in version 0.15.0.See https://github.com/crsmithdev/arrow/issues/612 for more details.
  ArrowParseWarning,
/Users/user/VE/myenv/lib/python3.7/site-packages/arrow/factory.py:202: ArrowParseWarning: The .get() parsing method without a format string will parse more strictly in version 0.15.0.See https://github.com/crsmithdev/arrow/issues/612 for more details.
```

The Arrow issue thread above indicates they intend to always produce the warning moving forward when the `.get()` method is used to parse strings, even when specifying a format parameter. 

So this PR silences those warnings as per the Arrow thread's recommendation

### Test environment changes

Since arrow no longer supports python 3.4, I removed it from the tox matrix.  I also added python 3.7 and more recent pypy versions. Since python 3.7 is not available in trusty, I changed the travis-ci distro to xenial

Also there are some minor quotation mark changes to appease what I assume are some newer more strict flake8 complaints. and added the new FI18 to the list of  ignored flake8 rules