### PR TITLE
Added `extended` parameter for list items

### DIFF
--- a/trakt/interfaces/users/lists/list_.py
+++ b/trakt/interfaces/users/lists/list_.py
@@ -31,11 +31,12 @@ class UsersListInterface(Interface):
             username=username
         )
 
-    def items(self, username, id, **kwargs):
+    def items(self, username, id, extended=None, **kwargs):
         # Send request
         response = self.http.get(
-            '/users/%s/lists/%s/items' % (clean_username(username), id),
-        )
+            '/users/%s/lists/%s/items' % (clean_username(username), id), query={
+                'extended': extended
+        })
 
         # Parse response
         items = self.get_data(response, **kwargs)


### PR DESCRIPTION
Per [https://trakt.docs.apiary.io/#reference/users/list-items/get-items-on-a-custom-list](url), extended info is supported by the Trakt.tv API.