### PR TITLE
Added `type` parameter for list items

### DIFF
--- a/trakt/interfaces/users/lists/list_.py
+++ b/trakt/interfaces/users/lists/list_.py
@@ -31,9 +31,10 @@ class UsersListInterface(Interface):
             username=username
         )
 
-    def items(self, username, id, extended=None, **kwargs):
+    def items(self, username, id, item_type=None, extended=None, **kwargs):
         # Send request
         response = self.http.get('/users/%s/lists/%s/items' % (clean_username(username), id), query={
+            'type': item_type,
             'extended': extended
         })
 


### PR DESCRIPTION
Per https://trakt.docs.apiary.io/#reference/users/list-items/get-items-on-a-custom-list, the `type` parameter is supported by the Trakt.tv API.