### PR TITLE
add handling for HTTP 429 (rate limiting)

### DIFF
--- a/trakt/core/http.py
+++ b/trakt/core/http.py
@@ -152,8 +152,8 @@ class HttpClient(object):
 
                 response = self.rebuild().send(request, timeout=timeout)
 
-            # Retry requests on exceptions or 5xx errors (when enabled)
-            if not retry or (not exc_info and response.status_code < 500):
+            # Retry requests on exceptions or 5xx/429 errors (when enabled)
+            if not retry or (not exc_info and response.status_code < 500 and response.status_code != 429):
                 break
 
             if exc_info:


### PR DESCRIPTION
As of October 2020, trakt.tv started implementing rate limits.
If rate limit is exceeded, HTTP 429 status is returned.
additional information: https://github.com/trakt/api-help/issues/220
related issue: #https://github.com/fuzeman/trakt.py/issues/86