### PR TITLE
these needs slugs not usernames

### DIFF
--- a/trakt/objects/list/base.py
+++ b/trakt/objects/list/base.py
@@ -228,7 +228,7 @@ class List(object):
         :rtype: :class:`~python:list` of :class:`trakt.objects.media.Media`
         """
 
-        return self._client['users/*/lists/*'].items(self.user.username, self.id, **kwargs)
+        return self._client['users/*/lists/*'].items(self.user.id, self.id, **kwargs)
 
     #
     # Actions
@@ -244,7 +244,7 @@ class List(object):
         :rtype: :class:`~python:bool`
         """
 
-        return self._client['users/*/lists/*'].like(self.user.username, self.id, **kwargs)
+        return self._client['users/*/lists/*'].like(self.user.id, self.id, **kwargs)
 
     def unlike(self, **kwargs):
         """Un-like the list.
@@ -256,7 +256,7 @@ class List(object):
         :rtype: :class:`~python:bool`
         """
 
-        return self._client['users/*/lists/*'].unlike(self.user.username, self.id, **kwargs)
+        return self._client['users/*/lists/*'].unlike(self.user.id, self.id, **kwargs)
 
     def __getstate__(self):
         state = self.__dict__


### PR DESCRIPTION
i was getting No items form this list:
`https://trakt.tv/users/hammers-lists/lists/creature-feature-monster-movies`

so i did some digging and when your calling the api your using the username not the user slug. For most it doesn't matter because it would just change some capitalization, but the URL above was being translated to `users/Hammers Lists/lists` instead of `users/hammers-lists/lists`. changing these from username to id fixed the problem in my test environment